### PR TITLE
task: id 003-visualization of financial metrics for administrative management

### DIFF
--- a/E-Dukate.Application/DTOs/Metrics/IncomeByPeriodDto.cs
+++ b/E-Dukate.Application/DTOs/Metrics/IncomeByPeriodDto.cs
@@ -1,0 +1,7 @@
+namespace E_Dukate.Application.DTOs.Metrics;
+
+public class IncomeByPeriodDto
+{
+    public string Period { get; set; } = string.Empty;
+    public decimal TotalIncome { get; set; }
+}

--- a/E-Dukate.Application/DTOs/Metrics/InstitutionEarningsDto.cs
+++ b/E-Dukate.Application/DTOs/Metrics/InstitutionEarningsDto.cs
@@ -1,0 +1,6 @@
+namespace E_Dukate.Application.DTOs.Metrics;
+
+public class InstitutionEarningsDto
+{
+    public decimal TotalInstitutionEarnings { get; set; } = 0;
+}

--- a/E-Dukate.Application/DTOs/Metrics/PaymentStatusCountDto.cs
+++ b/E-Dukate.Application/DTOs/Metrics/PaymentStatusCountDto.cs
@@ -1,0 +1,7 @@
+namespace E_Dukate.Application.DTOs.Metrics;
+
+public class PaymentStatusCountDto
+{
+    public int PendingCount { get; set; }
+    public int CompletedCount { get; set; }
+}

--- a/E-Dukate.Application/DTOs/Metrics/PendingVsCompletedPaymentsDto.cs
+++ b/E-Dukate.Application/DTOs/Metrics/PendingVsCompletedPaymentsDto.cs
@@ -1,0 +1,7 @@
+namespace E_Dukate.Application.DTOs.Metrics;
+
+public class PendingVsCompletedPaymentsDto
+{
+    public decimal PendingAmount { get; set; }
+    public decimal CompletedAmount { get; set; }
+}

--- a/E-Dukate.Application/Services/Metrics/PaymentMetricsService.cs
+++ b/E-Dukate.Application/Services/Metrics/PaymentMetricsService.cs
@@ -1,0 +1,206 @@
+using E_Dukate.Application.Services.Payments;
+using E_Dukate.Application.DTOs.Payments;
+using E_Dukate.Domain.Entities.Payments;
+using System.Globalization;
+using E_Dukate.Application.DTOs.Metrics;
+
+namespace E_Dukate.Application.Services.Metrics;
+
+public class PaymentMetricsService
+{
+    private readonly PaymentService _paymentService;
+
+    public PaymentMetricsService(PaymentService paymentService)
+    {
+        _paymentService = paymentService;
+    }
+
+    public async Task<List<IncomeByPeriodDto>> GetTotalIncomeByPeriodAsync(string? periodType, DateTime? startDate, DateTime? endDate)
+    {
+        periodType = string.IsNullOrWhiteSpace(periodType) ? "Monthly" : periodType;
+
+        if (!new[] { "monthly", "weekly", "yearly" }.Contains(periodType.ToLower()))
+            throw new ArgumentException("El tipo de período debe ser 'Monthly', 'Weekly' o 'Yearly'.");
+
+        var filter = new PaymentFilterDto
+        {
+            PageNumber = 1,
+            PageSize = int.MaxValue
+        };
+
+        var (payments, _) = await _paymentService.GetFilteredPaymentsAsync(filter);
+
+        var validDates = payments
+            .Select(p => p.FirstPaymentDate.HasValue ? p.FirstPaymentDate.Value : p.LastPaymentDate.HasValue ? p.LastPaymentDate.Value : (DateTime?)null)
+            .Where(d => d.HasValue)
+            .Select(d => d!.Value)
+            .ToList();
+
+        DateTime defaultStartDate = startDate ?? (validDates.Any() ? validDates.Min() : DateTime.UtcNow.AddYears(-1));
+        DateTime defaultEndDate = endDate ?? (validDates.Any() ? validDates.Max() : DateTime.UtcNow);
+
+        var filteredPayments = payments
+            .Where(p => (p.FirstPaymentDate.HasValue && p.FirstPaymentDate.Value >= defaultStartDate && p.FirstPaymentDate.Value <= defaultEndDate) ||
+                        (p.LastPaymentDate.HasValue && p.LastPaymentDate.Value >= defaultStartDate && p.LastPaymentDate.Value <= defaultEndDate))
+            .ToList();
+
+        var result = new List<IncomeByPeriodDto>();
+
+        switch (periodType.ToLower())
+        {
+            case "monthly":
+                result = filteredPayments
+                    .GroupBy(p => new
+                    {
+                        Year = p.FirstPaymentDate?.Year ?? p.LastPaymentDate?.Year,
+                        Month = p.FirstPaymentDate?.Month ?? p.LastPaymentDate?.Month
+                    })
+                    .Where(g => g.Key.Year.HasValue && g.Key.Month.HasValue)
+                    .Select(g => new IncomeByPeriodDto
+                    {
+                        Period = $"{g.Key.Year!.Value}-{g.Key.Month!.Value:00}",
+                        TotalIncome = g.Sum(p => p.TotalAmount)
+                    })
+                    .OrderBy(r => r.Period)
+                    .ToList();
+                break;
+
+            case "weekly":
+                result = filteredPayments
+                    .GroupBy(p =>
+                    {
+                        var date = p.FirstPaymentDate ?? p.LastPaymentDate;
+                        if (!date.HasValue) return null;
+                        var week = CultureInfo.InvariantCulture.Calendar.GetWeekOfYear(
+                            date.Value,
+                            CalendarWeekRule.FirstFourDayWeek,
+                            DayOfWeek.Monday);
+                        return new { Year = date.Value.Year, Week = week };
+                    })
+                    .Where(g => g.Key != null)
+                    .Select(g => new IncomeByPeriodDto
+                    {
+                        Period = $"{g.Key!.Year}-W{g.Key.Week:00}",
+                        TotalIncome = g.Sum(p => p.TotalAmount)
+                    })
+                    .OrderBy(r => r.Period)
+                    .ToList();
+                break;
+
+            case "yearly":
+                result = filteredPayments
+                    .GroupBy(p => p.FirstPaymentDate?.Year ?? p.LastPaymentDate?.Year)
+                    .Where(g => g.Key.HasValue)
+                    .Select(g => new IncomeByPeriodDto
+                    {
+                        Period = g.Key!.Value.ToString(),
+                        TotalIncome = g.Sum(p => p.TotalAmount)
+                    })
+                    .OrderBy(r => r.Period)
+                    .ToList();
+                break;
+        }
+
+        return result;
+    }
+
+    public async Task<PaymentStatusCountDto> GetPaymentStatusCountsAsync(DateTime? startDate, DateTime? endDate)
+    {
+        var filter = new PaymentFilterDto
+        {
+            PageNumber = 1,
+            PageSize = int.MaxValue
+        };
+
+        var (payments, _) = await _paymentService.GetFilteredPaymentsAsync(filter);
+
+        var validDates = payments
+            .Select(p => p.FirstPaymentDate.HasValue ? p.FirstPaymentDate.Value : p.LastPaymentDate.HasValue ? p.LastPaymentDate.Value : (DateTime?)null)
+            .Where(d => d.HasValue)
+            .Select(d => d!.Value)
+            .ToList();
+
+        DateTime defaultStartDate = startDate ?? (validDates.Any() ? validDates.Min() : DateTime.UtcNow.AddYears(-1));
+        DateTime defaultEndDate = endDate ?? (validDates.Any() ? validDates.Max() : DateTime.UtcNow);
+
+        var filteredPayments = payments
+            .Where(p => (p.FirstPaymentDate.HasValue && p.FirstPaymentDate.Value >= defaultStartDate && p.FirstPaymentDate.Value <= defaultEndDate) ||
+                        (p.LastPaymentDate.HasValue && p.LastPaymentDate.Value >= defaultStartDate && p.LastPaymentDate.Value <= defaultEndDate))
+            .ToList();
+
+        return new PaymentStatusCountDto
+        {
+            PendingCount = filteredPayments.Count(p => p.Status == PaymentStatus.Pending),
+            CompletedCount = filteredPayments.Count(p => p.Status == PaymentStatus.Completed)
+        };
+    }
+
+    public async Task<InstitutionEarningsDto> GetInstitutionEarningsAsync(DateTime? startDate, DateTime? endDate)
+    {
+        var filter = new PaymentFilterDto
+        {
+            PageNumber = 1,
+            PageSize = int.MaxValue
+        };
+
+        var (payments, _) = await _paymentService.GetFilteredPaymentsAsync(filter);
+
+        var validDates = payments
+            .Select(p => p.FirstPaymentDate.HasValue ? p.FirstPaymentDate.Value : p.LastPaymentDate.HasValue ? p.LastPaymentDate.Value : (DateTime?)null)
+            .Where(d => d.HasValue)
+            .Select(d => d!.Value)
+            .ToList();
+
+        DateTime defaultStartDate = startDate ?? (validDates.Any() ? validDates.Min() : DateTime.UtcNow.AddYears(-1));
+        DateTime defaultEndDate = endDate ?? (validDates.Any() ? validDates.Max() : DateTime.UtcNow);
+
+        var filteredPayments = payments
+            .Where(p => (p.FirstPaymentDate.HasValue && p.FirstPaymentDate.Value >= defaultStartDate && p.FirstPaymentDate.Value <= defaultEndDate) ||
+                        (p.LastPaymentDate.HasValue && p.LastPaymentDate.Value >= defaultStartDate && p.LastPaymentDate.Value <= defaultEndDate))
+            .ToList();
+
+        return new InstitutionEarningsDto
+        {
+            TotalInstitutionEarnings = filteredPayments.Sum(p => p.InstitutionAmount)
+        };
+    }
+
+    public async Task<List<int>> GetAvailableYearsAsync()
+    {
+        var filter = new PaymentFilterDto
+        {
+            PageNumber = 1,
+            PageSize = int.MaxValue
+        };
+
+        var (payments, _) = await _paymentService.GetFilteredPaymentsAsync(filter);
+
+        var years = payments
+            .SelectMany(p => new[] { p.FirstPaymentDate?.Year, p.LastPaymentDate?.Year })
+            .Where(y => y.HasValue)
+            .Select(y => y!.Value)
+            .Distinct()
+            .OrderBy(y => y)
+            .ToList();
+
+        return years;
+    }
+
+    public async Task<PendingVsCompletedPaymentsDto> GetPendingVsCompletedPaymentsAsync()
+    {
+        var filter = new PaymentFilterDto
+        {
+            PageNumber = 1,
+            PageSize = int.MaxValue
+        };
+
+        var (payments, _) = await _paymentService.GetFilteredPaymentsAsync(filter);
+        var result = new PendingVsCompletedPaymentsDto
+        {
+            PendingAmount = payments.Where(p => p.Status == PaymentStatus.Pending).Sum(p => p.PendingAmount),
+            CompletedAmount = payments.Where(p => p.Status == PaymentStatus.Completed).Sum(p => p.AmountPaid)
+        };
+
+        return result;
+    }
+}

--- a/E-Dukate.Presentation/Configuration/DependencyInjection.cs
+++ b/E-Dukate.Presentation/Configuration/DependencyInjection.cs
@@ -101,6 +101,7 @@ public static class DependencyInjection
         services.AddScoped<PaymentService>();
         services.AddScoped<MedicalHistoryMetricsService>();
         services.AddScoped<DemographicMetricsService>();
+        services.AddScoped<PaymentMetricsService>();
         services.AddSingleton<IConversationStateManager, ConversationStateManager>();
         return services;
     }

--- a/E-Dukate.Presentation/Controllers/Metrics/PaymentMetricsController.cs
+++ b/E-Dukate.Presentation/Controllers/Metrics/PaymentMetricsController.cs
@@ -1,0 +1,115 @@
+using E_Dukate.Application.Services.Metrics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace E_Dukate.Presentation.Controllers.Metrics;
+
+[ApiController]
+[Route("api/metrics/payments")]
+public class PaymentMetricsController : ControllerBase
+{
+    private readonly PaymentMetricsService _paymentMetricsService;
+
+    public PaymentMetricsController(PaymentMetricsService paymentMetricsService)
+    {
+        _paymentMetricsService = paymentMetricsService;
+    }
+
+    [HttpGet("total-income")]
+    public async Task<IActionResult> GetTotalIncomeByPeriod(
+        [FromQuery] string? periodType = null,
+        [FromQuery] DateTime? startDate = null,
+        [FromQuery] DateTime? endDate = null)
+    {
+        try
+        {
+            if (startDate.HasValue && endDate.HasValue && startDate > endDate)
+                return BadRequest(new { Error = "La fecha de inicio debe ser anterior o igual a la fecha de fin." });
+
+            var result = await _paymentMetricsService.GetTotalIncomeByPeriodAsync(periodType, startDate, endDate);
+            if (!result.Any())
+            {
+                return Ok(new { Message = "No hay datos disponibles para el período seleccionado." });
+            }
+            return Ok(result);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { Error = ex.Message });
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { Error = "Error al cargar los datos. Por favor, intenta de nuevo." });
+        }
+    }
+
+    [HttpGet("pending-vs-completed")]
+    public async Task<IActionResult> GetPendingVsCompletedPayments()
+    {
+        try
+        {
+            var result = await _paymentMetricsService.GetPendingVsCompletedPaymentsAsync();
+            if (result.PendingAmount == 0 && result.CompletedAmount == 0)
+            {
+                return Ok(new { Message = "No hay pagos registrados." });
+            }
+            return Ok(result);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { Error = "Error al cargar los datos. Por favor, intenta de nuevo." });
+        }
+    }
+
+    [HttpGet("status-counts")]
+    public async Task<IActionResult> GetPaymentStatusCounts(
+        [FromQuery] DateTime? startDate = null,
+        [FromQuery] DateTime? endDate = null)
+    {
+        try
+        {
+            if (startDate.HasValue && endDate.HasValue && startDate > endDate)
+                return BadRequest(new { Error = "La fecha de inicio debe ser anterior o igual a la fecha de fin." });
+
+            var result = await _paymentMetricsService.GetPaymentStatusCountsAsync(startDate, endDate);
+            if (result.PendingCount == 0 && result.CompletedCount == 0)
+            {
+                return Ok(new { Message = "No hay pagos registrados en el período seleccionado." });
+            }
+            return Ok(result);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { Error = "Error al cargar los datos. Por favor, intenta de nuevo." });
+        }
+    }
+
+    [HttpGet("institution-earnings")]
+    public async Task<IActionResult> GetInstitutionEarnings(
+        [FromQuery] DateTime? startDate = null,
+        [FromQuery] DateTime? endDate = null)
+    {
+        try
+        {
+            if (startDate.HasValue && endDate.HasValue && startDate > endDate)
+                return BadRequest(new { Error = "La fecha de inicio debe ser anterior o igual a la fecha de fin." });
+
+            var result = await _paymentMetricsService.GetInstitutionEarningsAsync(startDate, endDate);
+            if (result.TotalInstitutionEarnings == 0)
+            {
+                return Ok(new { Message = "No hay ganancias registradas para la institución en el período seleccionado." });
+            }
+            return Ok(result);
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { Error = "Error al cargar los datos. Por favor, intenta de nuevo." });
+        }
+    }
+
+    [HttpGet("available-years")]
+    public async Task<ActionResult<List<int>>> GetAvailableYears()
+    {
+        var years = await _paymentMetricsService.GetAvailableYearsAsync();
+        return Ok(years);
+    }
+}


### PR DESCRIPTION
# Pull Request Template 🚀

## 📝 Description
A payment metrics system was implemented in the backend to provide financial analysis and payment statistics. New DTOs and services were created to calculate revenue by period, count payment statuses, institutional profit, and compare pending versus completed payments. An API controller was also added to expose these metrics. This allows users to gain key insights into the financial performance and payment status of the platform.

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## 🧪 How Has This Been Tested?
Features can be tested using tools like Postman or Swagger to make HTTP requests to the API endpoints. Here's an overview of what can be tested:

**Metrics Endpoints:**
- `GET /api/metrics/payments/total-income`: Gets total income grouped by period (monthly, weekly, yearly) with optional date filters.
- `GET /api/metrics/payments/pending-vs-completed`: Compares pending versus completed payment amounts.
- `GET /api/metrics/payments/status-counts`: Returns counts of pending and completed payments over a date range.
- `GET /api/metrics/payments/institution-earnings`: Calculates the institution's total earnings for a period.
- `GET /api/metrics/payments/available-years`: Lists the years available for filtering data.
**Postman/Swagger Tests:**
- Send GET requests to each endpoint with parameters such as periodType, startDate, and endDate to verify that the returned data is correct.
- Test for error cases, such as invalid dates (startDate > endDate) or unsupported periods.
- Validate that the DTOs return the expected structure (e.g., Period and TotalIncome for revenue per period).

## ✅ Checklist
- [X] 🔎 I have performed a self-review of my own code
- [X] 🚫 My changes generate no new warnings