### PR TITLE
refactor: change logic to obtain income by period and pending vs completed Payments

### DIFF
--- a/E-Dukate.Application/Services/Metrics/PaymentMetricsService.cs
+++ b/E-Dukate.Application/Services/Metrics/PaymentMetricsService.cs
@@ -1,7 +1,6 @@
 using E_Dukate.Application.Services.Payments;
 using E_Dukate.Application.DTOs.Payments;
 using E_Dukate.Domain.Entities.Payments;
-using System.Globalization;
 using E_Dukate.Application.DTOs.Metrics;
 
 namespace E_Dukate.Application.Services.Metrics;
@@ -15,7 +14,7 @@ public class PaymentMetricsService
         _paymentService = paymentService;
     }
 
-    public async Task<List<IncomeByPeriodDto>> GetTotalIncomeByPeriodAsync(string? periodType, DateTime? startDate, DateTime? endDate)
+    public async Task<List<IncomeByPeriodDto>> GetTotalCompletedIncomeByPeriodAsync(string? periodType, DateTime? startDate, DateTime? endDate)
     {
         periodType = string.IsNullOrWhiteSpace(periodType) ? "Monthly" : periodType;
 
@@ -31,17 +30,15 @@ public class PaymentMetricsService
         var (payments, _) = await _paymentService.GetFilteredPaymentsAsync(filter);
 
         var validDates = payments
-            .Select(p => p.FirstPaymentDate.HasValue ? p.FirstPaymentDate.Value : p.LastPaymentDate.HasValue ? p.LastPaymentDate.Value : (DateTime?)null)
-            .Where(d => d.HasValue)
-            .Select(d => d!.Value)
+            .Where(p => p.LastPaymentDate.HasValue)
+            .Select(p => p.LastPaymentDate!.Value)
             .ToList();
 
         DateTime defaultStartDate = startDate ?? (validDates.Any() ? validDates.Min() : DateTime.UtcNow.AddYears(-1));
         DateTime defaultEndDate = endDate ?? (validDates.Any() ? validDates.Max() : DateTime.UtcNow);
 
-        var filteredPayments = payments
-            .Where(p => (p.FirstPaymentDate.HasValue && p.FirstPaymentDate.Value >= defaultStartDate && p.FirstPaymentDate.Value <= defaultEndDate) ||
-                        (p.LastPaymentDate.HasValue && p.LastPaymentDate.Value >= defaultStartDate && p.LastPaymentDate.Value <= defaultEndDate))
+        var forPayments = payments
+            .Where(p => p.LastPaymentDate.HasValue && p.LastPaymentDate.Value >= defaultStartDate && p.LastPaymentDate.Value <= defaultEndDate)
             .ToList();
 
         var result = new List<IncomeByPeriodDto>();
@@ -49,16 +46,15 @@ public class PaymentMetricsService
         switch (periodType.ToLower())
         {
             case "monthly":
-                result = filteredPayments
+                result = forPayments
                     .GroupBy(p => new
                     {
-                        Year = p.FirstPaymentDate?.Year ?? p.LastPaymentDate?.Year,
-                        Month = p.FirstPaymentDate?.Month ?? p.LastPaymentDate?.Month
+                        Year = p.LastPaymentDate!.Value.Year,
+                        Month = p.LastPaymentDate!.Value.Month
                     })
-                    .Where(g => g.Key.Year.HasValue && g.Key.Month.HasValue)
                     .Select(g => new IncomeByPeriodDto
                     {
-                        Period = $"{g.Key.Year!.Value}-{g.Key.Month!.Value:00}",
+                        Period = $"{g.Key.Year}-{g.Key.Month:00}",
                         TotalIncome = g.Sum(p => p.TotalAmount)
                     })
                     .OrderBy(r => r.Period)
@@ -66,21 +62,17 @@ public class PaymentMetricsService
                 break;
 
             case "weekly":
-                result = filteredPayments
+                result = forPayments
                     .GroupBy(p =>
                     {
-                        var date = p.FirstPaymentDate ?? p.LastPaymentDate;
-                        if (!date.HasValue) return null;
-                        var week = CultureInfo.InvariantCulture.Calendar.GetWeekOfYear(
-                            date.Value,
-                            CalendarWeekRule.FirstFourDayWeek,
-                            DayOfWeek.Monday);
-                        return new { Year = date.Value.Year, Week = week };
+                        var date = p.LastPaymentDate!.Value;
+                        var daysFromMonday = (date.DayOfWeek - DayOfWeek.Monday + 7) % 7;
+                        var weekStart = date.Date.AddDays(-daysFromMonday);
+                        return new { Year = weekStart.Year, Month = weekStart.Month, Day = weekStart.Day };
                     })
-                    .Where(g => g.Key != null)
                     .Select(g => new IncomeByPeriodDto
                     {
-                        Period = $"{g.Key!.Year}-W{g.Key.Week:00}",
+                        Period = $"{g.Key.Year}-{g.Key.Month:00}-{g.Key.Day:00} a {g.Key.Year}-{g.Key.Month:00}-{g.Key.Day + 6:00}",
                         TotalIncome = g.Sum(p => p.TotalAmount)
                     })
                     .OrderBy(r => r.Period)
@@ -88,12 +80,11 @@ public class PaymentMetricsService
                 break;
 
             case "yearly":
-                result = filteredPayments
-                    .GroupBy(p => p.FirstPaymentDate?.Year ?? p.LastPaymentDate?.Year)
-                    .Where(g => g.Key.HasValue)
+                result = forPayments
+                    .GroupBy(p => p.LastPaymentDate!.Value.Year)
                     .Select(g => new IncomeByPeriodDto
                     {
-                        Period = g.Key!.Value.ToString(),
+                        Period = g.Key.ToString(),
                         TotalIncome = g.Sum(p => p.TotalAmount)
                     })
                     .OrderBy(r => r.Period)
@@ -186,7 +177,7 @@ public class PaymentMetricsService
         return years;
     }
 
-    public async Task<PendingVsCompletedPaymentsDto> GetPendingVsCompletedPaymentsAsync()
+    public async Task<PendingVsCompletedPaymentsDto> GetPendingVsCompletedPaymentsAsync(DateTime? startDate, DateTime? endDate)
     {
         var filter = new PaymentFilterDto
         {
@@ -195,12 +186,29 @@ public class PaymentMetricsService
         };
 
         var (payments, _) = await _paymentService.GetFilteredPaymentsAsync(filter);
-        var result = new PendingVsCompletedPaymentsDto
-        {
-            PendingAmount = payments.Where(p => p.Status == PaymentStatus.Pending).Sum(p => p.PendingAmount),
-            CompletedAmount = payments.Where(p => p.Status == PaymentStatus.Completed).Sum(p => p.AmountPaid)
-        };
 
-        return result;
+        var filteredPayments = payments;
+        if (startDate.HasValue && endDate.HasValue)
+        {
+            var validDates = payments
+                .Select(p => p.FirstPaymentDate.HasValue ? p.FirstPaymentDate.Value : p.LastPaymentDate.HasValue ? p.LastPaymentDate.Value : (DateTime?)null)
+                .Where(d => d.HasValue)
+                .Select(d => d!.Value)
+                .ToList();
+
+            DateTime defaultStartDate = startDate.Value;
+            DateTime defaultEndDate = endDate.Value;
+
+            filteredPayments = payments
+                .Where(p => (p.FirstPaymentDate.HasValue && p.FirstPaymentDate.Value >= defaultStartDate && p.FirstPaymentDate.Value <= defaultEndDate) ||
+                            (p.LastPaymentDate.HasValue && p.LastPaymentDate.Value >= defaultStartDate && p.LastPaymentDate.Value <= defaultEndDate))
+                .ToList();
+        }
+
+        return new PendingVsCompletedPaymentsDto 
+        {
+            PendingAmount = filteredPayments.Where(p => p.Status == PaymentStatus.Pending).Sum(p => p.PendingAmount),
+            CompletedAmount = filteredPayments.Where(p => p.Status == PaymentStatus.Completed).Sum(p => p.AmountPaid)
+        };
     }
 }

--- a/E-Dukate.Presentation/Controllers/Metrics/PaymentMetricsController.cs
+++ b/E-Dukate.Presentation/Controllers/Metrics/PaymentMetricsController.cs
@@ -25,7 +25,7 @@ public class PaymentMetricsController : ControllerBase
             if (startDate.HasValue && endDate.HasValue && startDate > endDate)
                 return BadRequest(new { Error = "La fecha de inicio debe ser anterior o igual a la fecha de fin." });
 
-            var result = await _paymentMetricsService.GetTotalIncomeByPeriodAsync(periodType, startDate, endDate);
+            var result = await _paymentMetricsService.GetTotalCompletedIncomeByPeriodAsync(periodType, startDate, endDate);
             if (!result.Any())
             {
                 return Ok(new { Message = "No hay datos disponibles para el período seleccionado." });
@@ -43,14 +43,19 @@ public class PaymentMetricsController : ControllerBase
     }
 
     [HttpGet("pending-vs-completed")]
-    public async Task<IActionResult> GetPendingVsCompletedPayments()
+    public async Task<IActionResult> GetPendingVsCompletedPayments(
+        [FromQuery] DateTime? startDate = null,
+        [FromQuery] DateTime? endDate = null)
     {
         try
         {
-            var result = await _paymentMetricsService.GetPendingVsCompletedPaymentsAsync();
+            if (startDate.HasValue && endDate.HasValue && startDate > endDate)
+                return BadRequest(new { Error = "La fecha de inicio debe ser anterior o igual a la fecha de fin." });
+
+            var result = await _paymentMetricsService.GetPendingVsCompletedPaymentsAsync(startDate, endDate);
             if (result.PendingAmount == 0 && result.CompletedAmount == 0)
             {
-                return Ok(new { Message = "No hay pagos registrados." });
+                return Ok(new { Message = "No hay pagos registrados en el período seleccionado." });
             }
             return Ok(result);
         }


### PR DESCRIPTION
# Pull Request Template 🚀

## 📝 Description
This pull request introduces enhancements to two methods in the payment metrics service. The first method now calculates total completed income by period (monthly, weekly, or yearly) with improved date filtering and period grouping logic. The second method retrieves pending versus completed payment amounts, with added date range filtering to ensure accurate data within the specified period. These changes improve the accuracy and flexibility of payment metrics reporting.

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## 🧪 How Has This Been Tested?
The changes were tested using Postman and Swagger to verify the API endpoints. Test cases included:

- GET /api/metrics/payments/total-income
  - Tested with query parameters: periodType=Monthly, periodType=Weekly, periodType=Yearly, with and without startDate and endDate.
  - Validated response data for correct grouping (e.g., by month, week, or year) and accurate total income calculations.
  - Tested edge cases: invalid periodType (e.g., "Daily") to verify error handling, and empty data scenarios to ensure proper messaging.
- GET /api/metrics/payments/pending-vs-completed
  - Tested with and without startDate and endDate query parameters.
  - Verified response contains correct PendingAmount and CompletedAmount based on filtered payments.
  - Tested invalid date ranges (e.g., startDate after endDate) to confirm error responses.
  - Checked empty data scenarios to ensure appropriate messaging.

## ✅ Checklist
- [X] 🔎 I have performed a self-review of my own code
- [X] 🚫 My changes generate no new warnings