### PR TITLE
feat: id-015 - appointment registration

### DIFF
--- a/E-Dukate.Application/Services/Appointments/AppointmentService.cs
+++ b/E-Dukate.Application/Services/Appointments/AppointmentService.cs
@@ -100,14 +100,23 @@ public class AppointmentService
             var schedule = schedules.FirstOrDefault(s => s.Id == timeSlot.ScheduleId && s.DayOfWeek == dayOfWeek);
             if (schedule == null)
                 return Result.Failure($"The schedule is not available for {sessionDto.DayOfWeek}.");
-            
+
             var daysUntilNext = ((int)dayOfWeek - (int)currentDate.DayOfWeek + 7) % 7;
-            if (daysUntilNext == 0 && TimeOnly.FromDateTime(DateTime.UtcNow) > startTime)
+            var todayAtStartTime = currentDate.Add(startTime.ToTimeSpan());
+
+            // Si el día es hoy pero la hora ya pasó, saltar a la próxima semana
+            if (daysUntilNext == 0 && DateTime.UtcNow > todayAtStartTime)
+            {
                 daysUntilNext = 7;
+            }
 
             var sessionDate = currentDate.AddDays(daysUntilNext);
+
+            Console.WriteLine($"Day calc: Target={dayOfWeek}, Current={currentDate.DayOfWeek}");
+            Console.WriteLine($"DaysUntilNext: {daysUntilNext}");
+            Console.WriteLine($"Time check: Now={DateTime.UtcNow}, SlotStart={todayAtStartTime}");
             var sessionsToAssign = Math.Min(sessionsPerSlot, dto.SessionCount - sessionsAssigned);
-            var maxAttempts = 10;
+            var maxAttempts = 100;
 
             for (int i = 0; i < sessionsToAssign && sessionsAssigned < dto.SessionCount && maxAttempts > 0; i++)
             {
@@ -286,7 +295,7 @@ public class AppointmentService
 
         if (sessionsAssigned < dto.SessionCount)
             return Result.Failure("Not all requested sessions could be scheduled due to scheduling conflicts.");
-        
+
         foreach (var session in appointment.ScheduledSessions.ToList())
         {
             await _scheduledSessionRepository.DeleteAsync(session.Id);
@@ -558,7 +567,7 @@ public class AppointmentService
             query = query.Where(a => (a.Patient.Names + " " + a.Patient.LastNamePaternal + " " + (a.Patient.LastNameMaternal ?? "")).ToLower()
                 .Contains(patientSearch.ToLower()));
         }
-        
+
         var totalCount = await query.CountAsync();
 
         var items = await query
@@ -583,5 +592,100 @@ public class AppointmentService
         });
 
         return ValueResult<(IEnumerable<object>, int)>.Success((result, totalCount));
+    }
+
+    public async Task<ValueResult<List<(DateTime Start, DateTime End)>>> GetAppointmentPreviewAsync(AppointmentDto dto)
+    {
+        var validationResult = _validator.Validate(dto);
+        if (!validationResult.IsValid)
+            return ValueResult<List<(DateTime, DateTime)>>.Failure(string.Join(", ", validationResult.Errors.Select(e => e.ErrorMessage)));
+
+        var patient = await _patientRepository.GetByIdAsync(dto.PatientId);
+        if (patient == null)
+            return ValueResult<List<(DateTime, DateTime)>>.Failure("Paciente no encontrado.");
+
+        var specialty = await _specialtyRepository.GetByIdAsync(dto.SpecialtyId);
+        if (specialty == null)
+            return ValueResult<List<(DateTime, DateTime)>>.Failure("Especialidad no encontrada.");
+
+        var specialist = await _specialistRepository.GetByIdAsync(dto.SpecialistId);
+        if (specialist == null)
+            return ValueResult<List<(DateTime, DateTime)>>.Failure("Especialista no encontrado.");
+
+        var schedules = await _scheduleRepository.GetAll()
+            .Include(s => s.TimeSlots)
+            .Where(s => s.SpecialistId == dto.SpecialistId && s.Attends)
+            .ToListAsync();
+
+        var scheduledDates = new List<(DateTime, DateTime)>();
+        var currentDate = DateTime.UtcNow.Date; // Usar UTC
+        var sessionsAssigned = 0;
+
+        var sessionsPerSlot = dto.ScheduledSessions.Count > 0
+            ? (int)Math.Ceiling((double)dto.SessionCount / dto.ScheduledSessions.Count)
+            : 0;
+
+        foreach (var sessionDto in dto.ScheduledSessions)
+        {
+            if (!Enum.TryParse<DayOfWeek>(sessionDto.DayOfWeek, true, out var dayOfWeek))
+                return ValueResult<List<(DateTime, DateTime)>>.Failure($"Día de la semana inválido: {sessionDto.DayOfWeek}.");
+
+            var timeSlot = await _timeSlotRepository.GetAll()
+                .FirstOrDefaultAsync(ts => ts.Id == sessionDto.TimeSlotId);
+            if (timeSlot == null)
+                return ValueResult<List<(DateTime, DateTime)>>.Failure($"Horario no encontrado: {sessionDto.TimeSlotId}.");
+
+            if (!TimeOnly.TryParse(sessionDto.StartTime, out var startTime) ||
+                !TimeOnly.TryParse(sessionDto.EndTime, out var endTime))
+                return ValueResult<List<(DateTime, DateTime)>>.Failure($"Formato de hora inválido: {sessionDto.StartTime} - {sessionDto.EndTime}.");
+
+            var schedule = schedules.FirstOrDefault(s => s.Id == timeSlot.ScheduleId && s.DayOfWeek == dayOfWeek);
+            if (schedule == null)
+                return ValueResult<List<(DateTime, DateTime)>>.Failure($"El horario no está disponible para {sessionDto.DayOfWeek}.");
+
+            var daysUntilNext = ((int)dayOfWeek - (int)currentDate.DayOfWeek + 7) % 7;
+            if (daysUntilNext == 0 && TimeOnly.FromDateTime(DateTime.UtcNow) > startTime)
+                daysUntilNext = 7;
+
+            var sessionDate = currentDate.AddDays(daysUntilNext);
+            var sessionsToAssign = Math.Min(sessionsPerSlot, dto.SessionCount - sessionsAssigned);
+            var maxAttempts = 100;
+
+            for (int i = 0; i < sessionsToAssign && sessionsAssigned < dto.SessionCount && maxAttempts > 0; i++)
+            {
+                // Combinar la fecha y hora en UTC
+                var startSessionDateTime = new DateTime(
+                    sessionDate.Year, sessionDate.Month, sessionDate.Day,
+                    startTime.Hour, startTime.Minute, 0, DateTimeKind.Utc);
+                var endSessionDateTime = new DateTime(
+                    sessionDate.Year, sessionDate.Month, sessionDate.Day,
+                    endTime.Hour, endTime.Minute, 0, DateTimeKind.Utc);
+
+                var isOccupied = await _scheduledSessionRepository.GetAll()
+                    .AnyAsync(ss => ss.TimeSlotId == sessionDto.TimeSlotId &&
+                                    ss.StartSessionDateTime == startSessionDateTime &&
+                                    ss.Status != ScheduledSessionStatus.Cancelled);
+                if (!isOccupied)
+                {
+                    scheduledDates.Add((startSessionDateTime, endSessionDateTime));
+                    sessionsAssigned++;
+                    sessionDate = sessionDate.AddDays(7);
+                }
+                else
+                {
+                    sessionDate = sessionDate.AddDays(7);
+                    i--;
+                    maxAttempts--;
+                }
+            }
+
+            if (maxAttempts == 0)
+                return ValueResult<List<(DateTime, DateTime)>>.Failure($"No se encontraron fechas disponibles para {sessionDto.DayOfWeek} en el horario solicitado.");
+        }
+
+        if (sessionsAssigned < dto.SessionCount)
+            return ValueResult<List<(DateTime, DateTime)>>.Failure("No se pudieron programar todas las sesiones solicitadas debido a conflictos de horario.");
+
+        return ValueResult<List<(DateTime, DateTime)>>.Success(scheduledDates);
     }
 }

--- a/E-Dukate.Application/Services/Schedule/ScheduleService.cs
+++ b/E-Dukate.Application/Services/Schedule/ScheduleService.cs
@@ -53,7 +53,7 @@ public class ScheduleService
         try
         {
             await _timeSlotRepository.DeleteRelatedEntitiesAsync<ScheduledSession>(
-    timeSlotIdsToDelete, 
+    timeSlotIdsToDelete,
     ss => timeSlotIdsToDelete.Contains(ss.TimeSlotId));
 
             foreach (var timeSlotId in timeSlotIdsToDelete)
@@ -94,7 +94,7 @@ public class ScheduleService
                 };
 
                 await _scheduleRepository.AddAsync(schedule);
-                
+
                 foreach (var ts in dto.TimeSlots)
                 {
                     var timeSlot = new TimeSlot
@@ -151,5 +151,13 @@ public class ScheduleService
             .ToListAsync();
 
         return (items, totalCount);
+    }
+
+    public async Task<IEnumerable<Specialist>> GetSpecialistsBySpecialtyIdAsync(Guid specialtyId)
+    {
+        return await _specialistRepository.GetAll()
+            .Include(s => s.Specialty)
+            .Where(s => s.Specialty.Id == specialtyId)
+            .ToListAsync();
     }
 }

--- a/E-Dukate.Presentation/Controllers/Appointments/AppointmentsController.cs
+++ b/E-Dukate.Presentation/Controllers/Appointments/AppointmentsController.cs
@@ -115,4 +115,20 @@ public class AppointmentsController : ControllerBase
 
         return Ok();
     }
+
+    [HttpPost("preview")]
+    public async Task<IActionResult> GetAppointmentPreview([FromBody] AppointmentDto dto)
+    {
+        var result = await _appointmentService.GetAppointmentPreviewAsync(dto);
+        if (!result.IsSuccess)
+            return BadRequest(new { Error = result.ErrorMessage });
+
+        var previewData = result.Value.Select(item => new
+        {
+            start = item.Start.ToString("yyyy-MM-ddTHH:mm:ssZ"),
+            end = item.End.ToString("yyyy-MM-ddTHH:mm:ssZ")
+        }).ToList();
+
+        return Ok(previewData);
+    }
 }

--- a/E-Dukate.Presentation/Controllers/Schedule/SchedulesController.cs
+++ b/E-Dukate.Presentation/Controllers/Schedule/SchedulesController.cs
@@ -39,7 +39,19 @@ public class SchedulesController : ControllerBase
     public IActionResult GetSchedules(Guid specialistId)
     {
         var schedules = _scheduleService.GetSchedulesBySpecialistId(specialistId);
-        return Ok(schedules);
+        var response = schedules.Select(s => new
+        {
+            s.Id,
+            s.DayOfWeek,
+            s.Attends,
+            TimeSlots = s.TimeSlots.Select(ts => new
+            {
+                ts.Id,
+                ts.StartTime,
+                ts.EndTime
+            })
+        });
+        return Ok(response);
     }
 
     [HttpGet("search")]
@@ -66,5 +78,19 @@ public class SchedulesController : ControllerBase
             PageSize = pagination.PageSize,
             TotalPages = (int)Math.Ceiling(totalCount / (double)pagination.PageSize)
         });
+    }
+
+    [HttpGet("specialists-by-specialty/{specialtyId}")]
+    public async Task<IActionResult> GetSpecialistsBySpecialtyId(Guid specialtyId)
+    {
+        var specialists = await _scheduleService.GetSpecialistsBySpecialtyIdAsync(specialtyId);
+        var response = specialists.Select(s => new
+        {
+            s.Id,
+            s.Names,
+            s.LastNamePaternal,
+            s.LastNameMaternal
+        });
+        return Ok(response);
     }
 }


### PR DESCRIPTION
# Pull Request Template 🚀

## 📝 Description
The following improvements have been implemented in the Appointments Controller (`AppointmentsController`) and Appointment Service (`AppointmentService`):

1. **New `preview` endpoint**:
   - POST `/api/appointments/preview`
   - Allows previewing available appointment dates/times before creation
   - Returns an array of objects with start/end dates in ISO 8601 format

2. **Appointment scheduling enhancements**:
   - Improved time slot validation and availability checking
   - Better handling of scheduling conflicts
   - Automatic date calculation based on specialist availability
   - UTC support for all date/time handling

3. **Appointment creation improvements**:
   - More robust input validation
   - More descriptive error handling
   - Automatic payment record creation for appointments

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## 🧪 How Has This Been Tested?
The changes can be tested using:

1. **Swagger**:
   - Access Swagger UI at `/swagger`
   - Test the new `/api/appointments/preview` endpoint with valid data
   - Verify it returns correct UTC-formatted dates/times

2. **Postman**:
   - Test collection available at [Postman-collection-link-if-available]
   - Example preview request:
     ```json
     {
       "patientId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
       "specialtyId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
       "specialistId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
       "sessionCount": 4,
       "sessionCost": 65.0,
       "scheduledSessions": [
         {
           "dayOfWeek": "Monday",
           "startTime": "09:00",
           "endTime": "10:00",
           "timeSlotId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
           "status": "Pending"
         }
       ]
     }
     ```

## ✅ Checklist
- [x] 🔎 I have performed a self-review of my own code
- [x] 🚫 My changes generate no new warnings