### PR TITLE
feat: id 018 - upload pdf to medical history

### DIFF
--- a/E-Dukate.Application/DTOs/MedicalHistories/MedicalDocumentDto.cs
+++ b/E-Dukate.Application/DTOs/MedicalHistories/MedicalDocumentDto.cs
@@ -1,0 +1,8 @@
+namespace E_Dukate.Application.DTOs.MedicalHistories;
+
+public class MedicalDocumentDto
+{
+    public Guid Id { get; set; }
+    public string FileName { get; set; } = string.Empty;
+    public DateTime UploadDate { get; set; }
+}

--- a/E-Dukate.Application/DTOs/MedicalHistories/MedicalHistoryPermissionDto.cs
+++ b/E-Dukate.Application/DTOs/MedicalHistories/MedicalHistoryPermissionDto.cs
@@ -7,4 +7,5 @@ public class MedicalHistoryPermissionDto
     public bool CanEdit { get; set; }
     public string Status { get; set; } = "ContinuaEnTratamiento";
     public List<MedicalConsultationDto> Consultations { get; set; } = new List<MedicalConsultationDto>();
+    public List<MedicalDocumentDto> Documents { get; set; } = new List<MedicalDocumentDto>();
 }

--- a/E-Dukate.Application/Services/MedicalHistories/MedicalHistoryService.cs
+++ b/E-Dukate.Application/Services/MedicalHistories/MedicalHistoryService.cs
@@ -33,6 +33,8 @@ public class MedicalHistoryService
         var medicalHistory = await _medicalHistoryRepository.GetAll()
             .Include(mh => mh.Permissions)
                 .ThenInclude(p => p.Consultations)
+            .Include(mh => mh.Permissions)
+                .ThenInclude(p => p.Documents)
             .FirstOrDefaultAsync(mh => mh.PatientId == patientId);
 
         if (medicalHistory == null) return null;
@@ -54,6 +56,12 @@ public class MedicalHistoryService
                     Reason = c.Reason,
                     ConsultationDate = c.ConsultationDate,
                     Notes = c.Notes
+                }).ToList(),
+                Documents = p.Documents.Select(d => new MedicalDocumentDto
+                {
+                    Id = d.Id,
+                    FileName = d.FileName!,
+                    UploadDate = d.UploadDate
                 }).ToList()
             }).ToList()
         };
@@ -112,7 +120,7 @@ public class MedicalHistoryService
 
         if (permission == null)
             return false;
-            
+
         if (!permission.CanEdit)
             return false;
 

--- a/E-Dukate.Domain/Entities/MedicalHistories/MedicalDocument.cs
+++ b/E-Dukate.Domain/Entities/MedicalHistories/MedicalDocument.cs
@@ -1,0 +1,12 @@
+using E_Dukate.Domain.Primitives;
+
+namespace E_Dukate.Domain.Entities.MedicalHistories;
+
+public class MedicalDocument : Entity
+{
+    public Guid PermissionId { get; set; }
+    public MedicalHistoryPermission? Permission { get; set; }
+    public string? FileName { get; set; }
+    public string? FilePath { get; set; }
+    public DateTime UploadDate { get; set; }
+}

--- a/E-Dukate.Domain/Entities/MedicalHistories/MedicalHistoryPermission.cs
+++ b/E-Dukate.Domain/Entities/MedicalHistories/MedicalHistoryPermission.cs
@@ -12,4 +12,5 @@ public class MedicalHistoryPermission : Entity
     public bool CanEdit { get; set; } = true;
     public MedicalHistoryStatus Status { get; set; } = MedicalHistoryStatus.ContinuaEnTratamiento;
     public List<MedicalConsultation> Consultations { get; set; } = new List<MedicalConsultation>();
+    public List<MedicalDocument> Documents { get; set; } = new List<MedicalDocument>();
 }

--- a/E-Dukate.Infrastructure/Data/AppDbContext.cs
+++ b/E-Dukate.Infrastructure/Data/AppDbContext.cs
@@ -23,6 +23,7 @@ public class AppDbContext : DbContext
     public DbSet<MedicalHistory> MedicalHistories { get; set; }
     public DbSet<MedicalHistoryPermission> MedicalHistoryPermissions { get; set; }
     public DbSet<MedicalConsultation> MedicalConsultations { get; set; }
+    public DbSet<MedicalDocument> MedicalDocuments { get; set; }
     public DbSet<Appointment> Appointments { get; set; }
     public DbSet<ScheduledSession> ScheduledSessions { get; set; }
     public DbSet<Payment> Payments { get; set; }

--- a/E-Dukate.Infrastructure/Migrations/20250728210346_InitialCreate.Designer.cs
+++ b/E-Dukate.Infrastructure/Migrations/20250728210346_InitialCreate.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace E_Dukate.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    [Migration("20250705164532_InitialCreate")]
+    [Migration("20250728210346_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -177,6 +177,31 @@ namespace E_Dukate.Infrastructure.Migrations
                     b.HasIndex("SpecialistId");
 
                     b.ToTable("MedicalConsultations", (string)null);
+                });
+
+            modelBuilder.Entity("E_Dukate.Domain.Entities.MedicalHistories.MedicalDocument", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("FileName")
+                        .HasColumnType("text");
+
+                    b.Property<string>("FilePath")
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("PermissionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("UploadDate")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("PermissionId");
+
+                    b.ToTable("MedicalDocuments");
                 });
 
             modelBuilder.Entity("E_Dukate.Domain.Entities.MedicalHistories.MedicalHistory", b =>
@@ -561,6 +586,17 @@ namespace E_Dukate.Infrastructure.Migrations
                     b.Navigation("Specialist");
                 });
 
+            modelBuilder.Entity("E_Dukate.Domain.Entities.MedicalHistories.MedicalDocument", b =>
+                {
+                    b.HasOne("E_Dukate.Domain.Entities.MedicalHistories.MedicalHistoryPermission", "Permission")
+                        .WithMany("Documents")
+                        .HasForeignKey("PermissionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Permission");
+                });
+
             modelBuilder.Entity("E_Dukate.Domain.Entities.MedicalHistories.MedicalHistory", b =>
                 {
                     b.HasOne("E_Dukate.Domain.Entities.Users.Patient", "Patient")
@@ -666,6 +702,8 @@ namespace E_Dukate.Infrastructure.Migrations
             modelBuilder.Entity("E_Dukate.Domain.Entities.MedicalHistories.MedicalHistoryPermission", b =>
                 {
                     b.Navigation("Consultations");
+
+                    b.Navigation("Documents");
                 });
 
             modelBuilder.Entity("E_Dukate.Domain.Entities.Schedules.Schedule", b =>

--- a/E-Dukate.Infrastructure/Migrations/20250728210346_InitialCreate.cs
+++ b/E-Dukate.Infrastructure/Migrations/20250728210346_InitialCreate.cs
@@ -299,6 +299,27 @@ namespace E_Dukate.Infrastructure.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "MedicalDocuments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    PermissionId = table.Column<Guid>(type: "uuid", nullable: false),
+                    FileName = table.Column<string>(type: "text", nullable: true),
+                    FilePath = table.Column<string>(type: "text", nullable: true),
+                    UploadDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MedicalDocuments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MedicalDocuments_MedicalHistoryPermissions_PermissionId",
+                        column: x => x.PermissionId,
+                        principalTable: "MedicalHistoryPermissions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "TimeSlots",
                 columns: table => new
                 {
@@ -370,6 +391,11 @@ namespace E_Dukate.Infrastructure.Migrations
                 name: "IX_MedicalConsultations_SpecialistId",
                 table: "MedicalConsultations",
                 column: "SpecialistId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MedicalDocuments_PermissionId",
+                table: "MedicalDocuments",
+                column: "PermissionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_MedicalHistories_PatientId",
@@ -446,6 +472,9 @@ namespace E_Dukate.Infrastructure.Migrations
 
             migrationBuilder.DropTable(
                 name: "MedicalConsultations");
+
+            migrationBuilder.DropTable(
+                name: "MedicalDocuments");
 
             migrationBuilder.DropTable(
                 name: "Payments");

--- a/E-Dukate.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
+++ b/E-Dukate.Infrastructure/Migrations/AppDbContextModelSnapshot.cs
@@ -176,6 +176,31 @@ namespace E_Dukate.Infrastructure.Migrations
                     b.ToTable("MedicalConsultations", (string)null);
                 });
 
+            modelBuilder.Entity("E_Dukate.Domain.Entities.MedicalHistories.MedicalDocument", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("FileName")
+                        .HasColumnType("text");
+
+                    b.Property<string>("FilePath")
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("PermissionId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("UploadDate")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("PermissionId");
+
+                    b.ToTable("MedicalDocuments");
+                });
+
             modelBuilder.Entity("E_Dukate.Domain.Entities.MedicalHistories.MedicalHistory", b =>
                 {
                     b.Property<Guid>("Id")
@@ -558,6 +583,17 @@ namespace E_Dukate.Infrastructure.Migrations
                     b.Navigation("Specialist");
                 });
 
+            modelBuilder.Entity("E_Dukate.Domain.Entities.MedicalHistories.MedicalDocument", b =>
+                {
+                    b.HasOne("E_Dukate.Domain.Entities.MedicalHistories.MedicalHistoryPermission", "Permission")
+                        .WithMany("Documents")
+                        .HasForeignKey("PermissionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Permission");
+                });
+
             modelBuilder.Entity("E_Dukate.Domain.Entities.MedicalHistories.MedicalHistory", b =>
                 {
                     b.HasOne("E_Dukate.Domain.Entities.Users.Patient", "Patient")
@@ -663,6 +699,8 @@ namespace E_Dukate.Infrastructure.Migrations
             modelBuilder.Entity("E_Dukate.Domain.Entities.MedicalHistories.MedicalHistoryPermission", b =>
                 {
                     b.Navigation("Consultations");
+
+                    b.Navigation("Documents");
                 });
 
             modelBuilder.Entity("E_Dukate.Domain.Entities.Schedules.Schedule", b =>

--- a/E-Dukate.Presentation/Configuration/DependencyInjection.cs
+++ b/E-Dukate.Presentation/Configuration/DependencyInjection.cs
@@ -70,6 +70,7 @@ public static class DependencyInjection
         services.AddScoped<IGenericRepository<ScheduledSession>, GenericRepository<ScheduledSession>>();
         services.AddScoped<IGenericRepository<Payment>, GenericRepository<Payment>>();
         services.AddScoped<IGenericRepository<Specialist>, GenericRepository<Specialist>>();
+        services.AddScoped<IGenericRepository<MedicalDocument>, GenericRepository<MedicalDocument>>();
         return services;
     }
 

--- a/E-Dukate.Presentation/Controllers/Appointments/AppointmentsController.cs
+++ b/E-Dukate.Presentation/Controllers/Appointments/AppointmentsController.cs
@@ -123,7 +123,7 @@ public class AppointmentsController : ControllerBase
         if (!result.IsSuccess)
             return BadRequest(new { Error = result.ErrorMessage });
 
-        var previewData = result.Value.Select(item => new
+        var previewData = result.Value!.Select(item => new
         {
             start = item.Start.ToString("yyyy-MM-ddTHH:mm:ssZ"),
             end = item.End.ToString("yyyy-MM-ddTHH:mm:ssZ")

--- a/E-Dukate.Presentation/Controllers/MedicalHistories/MedicalConsultationsController.cs
+++ b/E-Dukate.Presentation/Controllers/MedicalHistories/MedicalConsultationsController.cs
@@ -4,6 +4,12 @@ using E_Dukate.Application.DTOs.MedicalHistories;
 using E_Dukate.Application.Services.MedicalHistories;
 using System.Security.Claims;
 using E_Dukate.Application.DTOs.Common;
+using Microsoft.AspNetCore.Http;
+using System.IO;
+using E_Dukate.Domain.Entities.MedicalHistories;
+using E_Dukate.Domain.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using E_Dukate.Infrastructure.Data;
 
 namespace E_Dukate.Presentation.Controllers.MedicalHistories;
 
@@ -13,10 +19,23 @@ namespace E_Dukate.Presentation.Controllers.MedicalHistories;
 public class MedicalConsultationsController : ControllerBase
 {
     private readonly MedicalConsultationService _medicalConsultationService;
+    private readonly IGenericRepository<MedicalDocument> _documentRepository;
+    private readonly IGenericRepository<MedicalHistoryPermission> _permissionRepository;
+    private readonly IWebHostEnvironment _environment;
+    private readonly AppDbContext _context;
 
-    public MedicalConsultationsController(MedicalConsultationService medicalConsultationService)
+    public MedicalConsultationsController(
+        MedicalConsultationService medicalConsultationService,
+        IGenericRepository<MedicalDocument> documentRepository,
+        IGenericRepository<MedicalHistoryPermission> permissionRepository,
+        IWebHostEnvironment environment,
+        AppDbContext context)
     {
         _medicalConsultationService = medicalConsultationService;
+        _documentRepository = documentRepository;
+        _permissionRepository = permissionRepository;
+        _environment = environment;
+        _context = context;
     }
 
     [HttpPost("histories/{medicalHistoryId}/specialists/{specialistId}/permissions/{permissionId}/consultation")]
@@ -92,5 +111,158 @@ public class MedicalConsultationsController : ControllerBase
             return BadRequest(result.ErrorMessage);
 
         return Ok(result.Value);
+    }
+
+    [HttpPost("permissions/{permissionId}/documents")]
+    [Authorize(Roles = "Specialist")]
+    public async Task<IActionResult> UploadDocument(Guid permissionId, IFormFile file)
+    {
+        try
+        {
+            var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var permission = await _context.MedicalHistoryPermissions
+                .FirstOrDefaultAsync(p => p.Id == permissionId && p.SpecialistId == Guid.Parse(userId!) && p.CanEdit);
+
+            if (permission == null)
+            {
+                return Forbid("No tienes permisos para subir documentos.");
+            }
+
+            if (file == null || file.Length == 0)
+            {
+                return BadRequest("No se proporcionó un archivo válido.");
+            }
+
+            var medicalHistory = await _context.MedicalHistories
+                .FirstOrDefaultAsync(h => h.Permissions.Any(p => p.Id == permissionId));
+
+            if (medicalHistory == null)
+            {
+                return NotFound("Historial médico no encontrado.");
+            }
+
+            var patientId = medicalHistory.PatientId;
+            var specialistId = permission.SpecialistId;
+            var documentId = Guid.NewGuid();
+            var fileName = file.FileName;
+            var filePath = Path.Combine("MedicalFiles", patientId.ToString(), specialistId.ToString(), $"{documentId}.pdf");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+            using (var stream = new FileStream(filePath, FileMode.Create))
+            {
+                await file.CopyToAsync(stream);
+            }
+
+            var document = new MedicalDocument
+            {
+                PermissionId = permissionId,
+                FileName = fileName,
+                FilePath = filePath,
+                UploadDate = DateTime.UtcNow
+            };
+
+            _context.MedicalDocuments.Add(document);
+            await _context.SaveChangesAsync();
+
+            return Ok(new { DocumentId = documentId.ToString() });
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new { error = $"Error al subir el documento: {ex.Message}" });
+        }
+    }
+
+    [HttpGet("documents/{documentId}")]
+    [Authorize(Roles = "Specialist,Administrator")]
+    public async Task<IActionResult> GetDocument(Guid documentId)
+    {
+        try
+        {
+            var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var document = await _context.MedicalDocuments
+                .Include(d => d.Permission)
+                .ThenInclude(p => p!.MedicalHistory)
+                .FirstOrDefaultAsync(d => d.Id == documentId);
+
+            if (document == null)
+            {
+                return NotFound("Documento no encontrado.");
+            }
+
+            if (User.IsInRole("Specialist"))
+            {
+                var medicalHistoryId = document.Permission!.MedicalHistoryId;
+                var hasPermission = await _context.MedicalHistoryPermissions
+                    .AnyAsync(p => p.MedicalHistoryId == medicalHistoryId && p.SpecialistId == Guid.Parse(userId!));
+
+                if (!hasPermission)
+                {
+                    return Forbid("No tienes permisos para ver este documento.");
+                }
+            }
+
+            var filePath = document.FilePath;
+            if (!System.IO.File.Exists(filePath))
+            {
+                return NotFound("Archivo no encontrado en el servidor.");
+            }
+
+            var fileBytes = await System.IO.File.ReadAllBytesAsync(filePath);
+            return File(fileBytes, "application/pdf", document.FileName);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new { error = $"Error al obtener el documento: {ex.Message}" });
+        }
+    }
+
+    [HttpDelete("documents/{documentId}")]
+    [Authorize(Roles = "Specialist,Administrator")]
+    public async Task<IActionResult> DeleteDocument(Guid documentId)
+    {
+        try
+        {
+            var userId = Guid.Parse(User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty);
+            var document = await _documentRepository.GetByIdAsync(documentId);
+            if (document == null)
+            {
+                return NotFound("Document not found.");
+            }
+
+            if (User.IsInRole("Specialist"))
+            {
+                var permission = await _permissionRepository.GetAll()
+                    .FirstOrDefaultAsync(p => p.Id == document.PermissionId);
+
+                if (permission == null || permission.SpecialistId != userId)
+                {
+                    return Unauthorized("You do not have permission to delete this document.");
+                }
+
+                if (!permission.CanEdit)
+                {
+                    return Unauthorized("You do not have editing permissions.");
+                }
+            }
+
+            if (System.IO.File.Exists(document.FilePath))
+            {
+                System.IO.File.Delete(document.FilePath);
+                Console.WriteLine($"DeleteDocument - File deleted: {document.FilePath}");
+            }
+            else
+            {
+                Console.WriteLine($"DeleteDocument - File not found: {document.FilePath}");
+            }
+
+            await _documentRepository.DeleteAsync(documentId);
+            await _context.SaveChangesAsync();
+
+            return Ok("Document deleted successfully.");
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new { error = $"Error al eliminar el documento: {ex.Message}" });
+        }
     }
 }

--- a/E-Dukate.Presentation/Controllers/MedicalHistories/MedicalHistoriesController.cs
+++ b/E-Dukate.Presentation/Controllers/MedicalHistories/MedicalHistoriesController.cs
@@ -26,7 +26,33 @@ public class MedicalHistoriesController : ControllerBase
         if (medicalHistory == null)
             return NotFound("Medical History were not found for the specified patient.");
 
-        return Ok(medicalHistory);
+        var historyDto = new MedicalHistoryDto
+        {
+            Id = medicalHistory.Id,
+            PatientId = medicalHistory.PatientId,
+            Permissions = medicalHistory.Permissions.Select(p => new MedicalHistoryPermissionDto
+            {
+                Id = p.Id,
+                SpecialistId = p.SpecialistId,
+                CanEdit = p.CanEdit,
+                Status = p.Status,
+                Consultations = p.Consultations.Select(c => new MedicalConsultationDto
+                {
+                    Id = c.Id,
+                    SpecialistId = c.SpecialistId,
+                    Reason = c.Reason,
+                    ConsultationDate = c.ConsultationDate,
+                    Notes = c.Notes
+                }).ToList(),
+                Documents = p.Documents.Select(d => new MedicalDocumentDto
+                {
+                    Id = d.Id,
+                    FileName = d.FileName,
+                    UploadDate = d.UploadDate
+                }).ToList()
+            }).ToList()
+        };
+        return Ok(historyDto);
     }
 
     [HttpPost("permissions")]


### PR DESCRIPTION
# Pull Request Template 🚀

## 📝 Description
This pull request implements functionality for managing PDF documents in the medical history system. The changes include endpoints for uploading, viewing, and deleting PDF documents associated with medical history permissions. The implementation ensures secure access control, allowing only authorized specialists and administrators to perform these actions. This addresses the requirement to enhance the medical history module with document management capabilities.

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## 🧪 How Has This Been Tested?
The changes were tested using Swagger and Postman to verify the functionality of the new endpoints. The following tests were conducted:
- **Upload Document:** Tested the `POST /api/MedicalConsultations/permissions/{permissionId}/documents` endpoint by uploading a PDF file with valid permissions as a Specialist, verifying the file is stored correctly and the response contains the document ID.
- **View Document:** Tested the `GET /api/MedicalConsultations/documents/{documentId}` endpoint by retrieving a PDF file by document ID as both Specialist and Administrator, ensuring proper access control and correct file delivery.
- **Delete Document:** Tested the `DELETE /api/MedicalConsultations/documents/{documentId}` endpoint by deleting a PDF file by document ID, confirming the file is removed from storage and the database, with appropriate permission checks.
- **Error Handling:** Tested scenarios with invalid permissions, non-existent documents, and unauthorized access for all endpoints, ensuring proper error responses.

## ✅ Checklist
- [X] 🔎 I have performed a self-review of my own code
- [X] 🚫 My changes generate no new warnings