### PR TITLE
feat: id 016 and 017 - cancel and modify appointments

### DIFF
--- a/E-Dukate.Application/DTOs/Appointments/RescheduleSessionDto.cs
+++ b/E-Dukate.Application/DTOs/Appointments/RescheduleSessionDto.cs
@@ -1,0 +1,10 @@
+namespace E_Dukate.Application.DTOs.Appointments;
+
+public class RescheduleSessionDto
+{
+    public Guid SessionId { get; set; }
+    public Guid TimeSlotId { get; set; }
+    public string DayOfWeek { get; set; } = string.Empty;
+    public string StartTime { get; set; } = string.Empty;
+    public string EndTime { get; set; } = string.Empty;
+}

--- a/E-Dukate.Application/Services/Appointments/AppointmentService.cs
+++ b/E-Dukate.Application/Services/Appointments/AppointmentService.cs
@@ -648,7 +648,7 @@ public class AppointmentService
             .ToListAsync();
 
         var scheduledDates = new List<(DateTime, DateTime)>();
-        var currentDate = DateTime.UtcNow.Date; // Usar UTC
+        var currentDate = DateTime.UtcNow.Date;
         var sessionsAssigned = 0;
 
         var sessionsPerSlot = dto.ScheduledSessions.Count > 0

--- a/E-Dukate.Application/Services/Appointments/AppointmentService.cs
+++ b/E-Dukate.Application/Services/Appointments/AppointmentService.cs
@@ -376,32 +376,44 @@ public class AppointmentService
 
         if (session.Status == ScheduledSessionStatus.Cancelled)
             return Result.Failure("La sesión ya está cancelada.");
-        
+
         if (session.StartSessionDateTime <= DateTime.UtcNow)
             return Result.Failure("No se puede cancelar una sesión pasada.");
-        
+
         session.Status = ScheduledSessionStatus.Cancelled;
 
         var activeSessions = appointment.ScheduledSessions
             .Count(s => s.Status != ScheduledSessionStatus.Cancelled);
 
-        var newTotalAmount = appointment.Payment.SessionCost * activeSessions;
+        if (activeSessions == 0)
+        {
+            var deleteResult = await _paymentService.DeletePaymentAsync(appointment.Payment.Id);
+            if (!deleteResult.IsSuccess)
+                return Result.Failure($"Error al eliminar el pago: {deleteResult.ErrorMessage}");
 
-        var originalAmountPaid = appointment.Payment.AmountPaid;
+            appointment.Payment = null;
+            appointment.PaymentId = null;
+        }
+        else
+        {
+            var newTotalAmount = appointment.Payment.SessionCost * activeSessions;
 
-        appointment.Payment.SessionCount = activeSessions;
-        appointment.Payment.TotalAmount = newTotalAmount;
+            var originalAmountPaid = appointment.Payment.AmountPaid;
 
-        appointment.Payment.AmountPaid = originalAmountPaid;
+            appointment.Payment.SessionCount = activeSessions;
+            appointment.Payment.TotalAmount = newTotalAmount;
 
-        appointment.Payment.PendingAmount = Math.Max(0, newTotalAmount - originalAmountPaid);
+            appointment.Payment.AmountPaid = originalAmountPaid;
 
-        appointment.Payment.Status = appointment.Payment.PendingAmount == 0
-            ? PaymentStatus.Completed
-            : PaymentStatus.Pending;
-        
-        appointment.Payment.SpecialistAmount = newTotalAmount * 0.5m;
-        appointment.Payment.InstitutionAmount = newTotalAmount * 0.5m;
+            appointment.Payment.PendingAmount = Math.Max(0, newTotalAmount - originalAmountPaid);
+
+            appointment.Payment.Status = appointment.Payment.PendingAmount == 0
+                ? PaymentStatus.Completed
+                : PaymentStatus.Pending;
+
+            appointment.Payment.SpecialistAmount = newTotalAmount * 0.5m;
+            appointment.Payment.InstitutionAmount = newTotalAmount * 0.5m;
+        }
 
         await _appointmentRepository.UpdateAsync(appointment);
 

--- a/E-Dukate.Application/Services/Appointments/AppointmentService.cs
+++ b/E-Dukate.Application/Services/Appointments/AppointmentService.cs
@@ -104,7 +104,6 @@ public class AppointmentService
             var daysUntilNext = ((int)dayOfWeek - (int)currentDate.DayOfWeek + 7) % 7;
             var todayAtStartTime = currentDate.Add(startTime.ToTimeSpan());
 
-            // Si el día es hoy pero la hora ya pasó, saltar a la próxima semana
             if (daysUntilNext == 0 && DateTime.UtcNow > todayAtStartTime)
             {
                 daysUntilNext = 7;
@@ -338,32 +337,6 @@ public class AppointmentService
         return Result.Success();
     }
 
-    public async Task<Result> DeleteAppointmentAsync(Guid id)
-    {
-        var appointment = await _appointmentRepository.GetAll()
-            .Include(a => a.ScheduledSessions)
-            .Include(a => a.Payment)
-            .FirstOrDefaultAsync(a => a.Id == id);
-        if (appointment == null)
-            return Result.Failure("Appointment not found.");
-
-        foreach (var session in appointment.ScheduledSessions)
-        {
-            session.Status = ScheduledSessionStatus.Cancelled;
-            await _scheduledSessionRepository.UpdateAsync(session);
-        }
-
-        if (appointment.Payment != null)
-        {
-            var paymentResult = await _paymentService.UpdatePaymentOnSessionCancellationAsync(id);
-            if (!paymentResult.IsSuccess)
-                return paymentResult;
-        }
-
-        await _appointmentRepository.DeleteAsync(id);
-        return Result.Success();
-    }
-
     public async Task<Result> ConfirmSessionAsync(Guid sessionId, Guid patientId)
     {
         var session = await _scheduledSessionRepository.GetAll()
@@ -384,89 +357,119 @@ public class AppointmentService
         return Result.Success();
     }
 
-    public async Task<Result> CancelSessionAsync(Guid sessionId, Guid patientId)
+    public async Task<Result> CancelSessionAsync(Guid appointmentId, Guid sessionId)
     {
-        var session = await _scheduledSessionRepository.GetAll()
-            .Include(ss => ss.Appointment)
-            .ThenInclude(a => a!.Patient)
-            .FirstOrDefaultAsync(ss => ss.Id == sessionId);
-        if (session == null)
-            return Result.Failure("Session not found.");
+        var appointment = await _appointmentRepository.GetAll()
+            .Include(a => a.ScheduledSessions)
+            .Include(a => a.Payment)
+            .FirstOrDefaultAsync(a => a.Id == appointmentId);
 
-        if (session.Appointment!.PatientId != patientId)
-            return Result.Failure("You do not have permission to cancel this session.");
+        if (appointment == null)
+            return Result.Failure("Cita no encontrada.");
+
+        if (appointment.Payment == null)
+            return Result.Failure("La cita no tiene pago asociado.");
+
+        var session = appointment.ScheduledSessions.FirstOrDefault(s => s.Id == sessionId);
+        if (session == null)
+            return Result.Failure("Sesión no encontrada.");
 
         if (session.Status == ScheduledSessionStatus.Cancelled)
-            return Result.Failure("The session is already cancelled.");
-
+            return Result.Failure("La sesión ya está cancelada.");
+        
+        if (session.StartSessionDateTime <= DateTime.UtcNow)
+            return Result.Failure("No se puede cancelar una sesión pasada.");
+        
         session.Status = ScheduledSessionStatus.Cancelled;
-        await _scheduledSessionRepository.UpdateAsync(session);
 
-        var paymentResult = await _paymentService.UpdatePaymentOnSessionCancellationAsync(session.AppointmentId);
-        if (!paymentResult.IsSuccess)
-            return paymentResult;
+        var activeSessions = appointment.ScheduledSessions
+            .Count(s => s.Status != ScheduledSessionStatus.Cancelled);
+
+        var newTotalAmount = appointment.Payment.SessionCost * activeSessions;
+
+        var originalAmountPaid = appointment.Payment.AmountPaid;
+
+        appointment.Payment.SessionCount = activeSessions;
+        appointment.Payment.TotalAmount = newTotalAmount;
+
+        appointment.Payment.AmountPaid = originalAmountPaid;
+
+        appointment.Payment.PendingAmount = Math.Max(0, newTotalAmount - originalAmountPaid);
+
+        appointment.Payment.Status = appointment.Payment.PendingAmount == 0
+            ? PaymentStatus.Completed
+            : PaymentStatus.Pending;
+        
+        appointment.Payment.SpecialistAmount = newTotalAmount * 0.5m;
+        appointment.Payment.InstitutionAmount = newTotalAmount * 0.5m;
+
+        await _appointmentRepository.UpdateAsync(appointment);
 
         return Result.Success();
     }
 
-    public async Task<Result> RescheduleSessionAsync(Guid sessionId, Guid patientId, ScheduledSessionDto dto)
+    public async Task<Result> RescheduleSessionAsync(Guid appointmentId, RescheduleSessionDto dto)
     {
-        var session = await _scheduledSessionRepository.GetAll()
-            .Include(ss => ss.Appointment)
-            .ThenInclude(a => a!.Specialist)
-            .FirstOrDefaultAsync(ss => ss.Id == sessionId);
-        if (session == null)
-            return Result.Failure("Session not found.");
-
-        if (session.Appointment!.PatientId != patientId)
-            return Result.Failure("You do not have permission to reschedule this session.");
-
         if (!Enum.TryParse<DayOfWeek>(dto.DayOfWeek, true, out var dayOfWeek))
-            return Result.Failure($"Invalid day of the week: {dto.DayOfWeek}.");
+            return Result.Failure($"Día de la semana inválido: {dto.DayOfWeek}.");
 
         if (!TimeOnly.TryParse(dto.StartTime, out var startTime) ||
             !TimeOnly.TryParse(dto.EndTime, out var endTime))
-            return Result.Failure($"Invalid time format: {dto.StartTime} - {dto.EndTime}.");
+            return Result.Failure($"Formato de hora inválido: {dto.StartTime} - {dto.EndTime}.");
+        
+        var appointment = await _appointmentRepository.GetAll()
+            .Include(a => a.ScheduledSessions)
+            .FirstOrDefaultAsync(a => a.Id == appointmentId);
 
-        var timeSlot = await _timeSlotRepository.GetAll()
-            .FirstOrDefaultAsync(ts => ts.Id == dto.TimeSlotId &&
-                                       ts.StartTime == startTime &&
-                                       ts.EndTime == endTime);
-        if (timeSlot == null)
-            return Result.Failure($"Schedule not found: {dto.StartTime} - {dto.EndTime}.");
+        if (appointment == null)
+            return Result.Failure("Cita no encontrada.");
 
+        var session = appointment.ScheduledSessions.FirstOrDefault(s => s.Id == dto.SessionId);
+        if (session == null)
+            return Result.Failure("Sesión no encontrada.");
+        
         var schedules = await _scheduleRepository.GetAll()
             .Include(s => s.TimeSlots)
-            .Where(s => s.SpecialistId == session.Appointment.SpecialistId && s.Attends)
+            .Where(s => s.SpecialistId == appointment.SpecialistId && s.Attends)
             .ToListAsync();
 
-        var schedule = schedules.FirstOrDefault(s => s.Id == timeSlot.ScheduleId && s.DayOfWeek == dayOfWeek);
-        if (schedule == null)
-            return Result.Failure($"The schedule is not available for {dto.DayOfWeek}.");
+        var timeSlot = await _timeSlotRepository.GetByIdAsync(dto.TimeSlotId);
+        if (timeSlot == null || timeSlot.StartTime != startTime || timeSlot.EndTime != endTime)
+            return Result.Failure("Horario no válido.");
 
+        var schedule = schedules.FirstOrDefault(s =>
+            s.Id == timeSlot.ScheduleId && s.DayOfWeek == dayOfWeek);
+
+        if (schedule == null)
+            return Result.Failure($"El horario no está disponible para {dto.DayOfWeek}.");
+        
         var currentDate = DateTime.UtcNow.Date;
         var daysUntilNext = ((int)dayOfWeek - (int)currentDate.DayOfWeek + 7) % 7;
-        if (daysUntilNext == 0 && TimeOnly.FromDateTime(DateTime.UtcNow) > startTime)
+        var todayAtStartTime = currentDate.Add(startTime.ToTimeSpan());
+
+        if (daysUntilNext == 0 && DateTime.UtcNow > todayAtStartTime)
             daysUntilNext = 7;
 
-        var sessionDate = currentDate.AddDays(daysUntilNext);
-        var startSessionDateTime = sessionDate.Add(startTime.ToTimeSpan());
-        var endSessionDateTime = sessionDate.Add(endTime.ToTimeSpan());
+        var newDate = currentDate.AddDays(daysUntilNext);
+        var newStartDateTime = newDate.Add(startTime.ToTimeSpan());
+        var newEndDateTime = newDate.Add(endTime.ToTimeSpan());
 
         var isOccupied = await _scheduledSessionRepository.GetAll()
-            .AnyAsync(ss => ss.TimeSlotId == dto.TimeSlotId &&
-                            ss.StartSessionDateTime.Date == sessionDate &&
-                            ss.StartSessionDateTime.Hour == startTime.Hour &&
-                            ss.StartSessionDateTime.Minute == startTime.Minute &&
-                            ss.Id != sessionId);
-        if (isOccupied)
-            return Result.Failure($"The schedule {startSessionDateTime} is already occupied.");
+            .AnyAsync(ss =>
+                ss.TimeSlotId == dto.TimeSlotId &&
+                ss.StartSessionDateTime.Date == newDate.Date &&
+                ss.StartSessionDateTime.Hour == startTime.Hour &&
+                ss.StartSessionDateTime.Minute == startTime.Minute &&
+                ss.Id != dto.SessionId);
 
-        session.TimeSlotId = dto.TimeSlotId;
-        session.StartSessionDateTime = startSessionDateTime;
-        session.EndSessionDateTime = endSessionDateTime;
+        if (isOccupied)
+            return Result.Failure("El horario seleccionado no está disponible.");
+        
+        session.StartSessionDateTime = newStartDateTime;
+        session.EndSessionDateTime = newEndDateTime;
         session.Status = ScheduledSessionStatus.Rescheduled;
-        await _scheduledSessionRepository.UpdateAsync(session);
+
+        await _appointmentRepository.UpdateAsync(appointment);
 
         return Result.Success();
     }
@@ -527,16 +530,12 @@ public class AppointmentService
     string? patientSearch,
     PaginationParams pagination)
     {
-        var filterDate = date.HasValue
-            ? DateTime.SpecifyKind(date.Value.Date, DateTimeKind.Utc)
-            : DateTime.SpecifyKind(DateTime.UtcNow.Date, DateTimeKind.Utc);
-
         var query = _appointmentRepository.GetAll()
             .Include(a => a.Patient)
             .Include(a => a.Specialty)
             .Include(a => a.Specialist)
             .Include(a => a.ScheduledSessions)
-            .ThenInclude(ss => ss.TimeSlot)
+                .ThenInclude(ss => ss.TimeSlot)
             .AsQueryable();
 
         if (patientId.HasValue)
@@ -549,9 +548,19 @@ public class AppointmentService
             query = query.Where(a => a.SpecialistId == specialistId.Value);
         }
 
+        DateTime filterDate;
+        if (date.HasValue)
+        {
+            filterDate = DateTime.SpecifyKind(date.Value.Date, DateTimeKind.Utc);
+        }
+        else
+        {
+            filterDate = DateTime.SpecifyKind(DateTime.UtcNow.Date, DateTimeKind.Utc);
+        }
+
         query = query.Where(a => a.ScheduledSessions.Any(ss =>
             DateTime.SpecifyKind(ss.StartSessionDateTime, DateTimeKind.Utc).Date == filterDate));
-
+        
         if (!string.IsNullOrWhiteSpace(status))
         {
             if (!Enum.TryParse<ScheduledSessionStatus>(status, true, out var parsedStatus))
@@ -564,32 +573,53 @@ public class AppointmentService
 
         if (!string.IsNullOrWhiteSpace(patientSearch))
         {
-            query = query.Where(a => (a.Patient.Names + " " + a.Patient.LastNamePaternal + " " + (a.Patient.LastNameMaternal ?? "")).ToLower()
-                .Contains(patientSearch.ToLower()));
+            query = query.Where(a => (a.Patient.Names + " " + a.Patient.LastNamePaternal + " " + (a.Patient.LastNameMaternal ?? ""))
+                .ToLower().Contains(patientSearch.ToLower()));
         }
 
         var totalCount = await query.CountAsync();
 
-        var items = await query
+        var appointments = await query
             .OrderBy(a => a.ScheduledSessions.FirstOrDefault()!.StartSessionDateTime)
             .Skip((pagination.PageNumber - 1) * pagination.PageSize)
             .Take(pagination.PageSize)
             .ToListAsync();
+        
+        var result = new List<object>();
 
-        var result = items.Select(a =>
+        foreach (var appointment in appointments)
         {
-            var session = a.ScheduledSessions.FirstOrDefault(ss =>
-                DateTime.SpecifyKind(ss.StartSessionDateTime, DateTimeKind.Utc).Date == filterDate);
-            return new
+            foreach (var session in appointment.ScheduledSessions)
             {
-                a.Id,
-                StartTime = session?.StartSessionDateTime.ToString("HH:mm"),
-                EndTime = session?.EndSessionDateTime.ToString("HH:mm"),
-                PatientName = $"{a.Patient.Names} {a.Patient.LastNamePaternal} {(a.Patient.LastNameMaternal ?? "")}".Trim(),
-                SpecialistName = $"{a.Specialist.Names} {a.Specialist.LastNamePaternal} {(a.Specialist.LastNameMaternal ?? "")}".Trim(),
-                Status = session?.Status.ToString() ?? GetAppointmentStatus(a)
-            };
-        });
+                var sessionDate = DateTime.SpecifyKind(session.StartSessionDateTime, DateTimeKind.Utc).Date;
+                if (sessionDate != filterDate)
+                    continue;
+                
+                if (!string.IsNullOrWhiteSpace(status))
+                {
+                    if (session.Status.ToString() != status)
+                        continue;
+                }
+
+                result.Add(new
+                {
+                    appointment.Id,
+                    StartTime = session.StartSessionDateTime.ToString("HH:mm"),
+                    EndTime = session.EndSessionDateTime.ToString("HH:mm"),
+                    appointment.PatientId,
+                    PatientName = $"{appointment.Patient.Names} {appointment.Patient.LastNamePaternal} {(appointment.Patient.LastNameMaternal ?? "")}".Trim(),
+                    appointment.SpecialistId,
+                    SpecialistName = $"{appointment.Specialist.Names} {appointment.Specialist.LastNamePaternal} {(appointment.Specialist.LastNameMaternal ?? "")}".Trim(),
+                    appointment.SpecialtyId,
+                    SpecialtyName = appointment.Specialty.TypeOfSpecialty,
+                    Status = session.Status.ToString(),
+                    SessionId = session.Id,
+                    DayOfWeek = session.StartSessionDateTime.DayOfWeek.ToString(),
+                    TimeSlotId = session.TimeSlotId,
+                    SessionStatus = session.Status.ToString()
+                });
+            }
+        }
 
         return ValueResult<(IEnumerable<object>, int)>.Success((result, totalCount));
     }
@@ -653,7 +683,6 @@ public class AppointmentService
 
             for (int i = 0; i < sessionsToAssign && sessionsAssigned < dto.SessionCount && maxAttempts > 0; i++)
             {
-                // Combinar la fecha y hora en UTC
                 var startSessionDateTime = new DateTime(
                     sessionDate.Year, sessionDate.Month, sessionDate.Day,
                     startTime.Hour, startTime.Minute, 0, DateTimeKind.Utc);

--- a/E-Dukate.Application/Services/Payments/PaymentService.cs
+++ b/E-Dukate.Application/Services/Payments/PaymentService.cs
@@ -99,10 +99,13 @@ public class PaymentService
         if (appointment.Payment == null)
             return Result.Success();
 
+        var payment = appointment.Payment;
         var activeSessionCount = appointment.ScheduledSessions
             .Count(ss => ss.Status != ScheduledSessionStatus.Cancelled);
 
-        var payment = appointment.Payment;
+        if (payment.SessionCount == activeSessionCount)
+            return Result.Success();
+
         payment.SessionCount = activeSessionCount;
         payment.TotalAmount = payment.SessionCost * activeSessionCount;
         payment.PendingAmount = payment.TotalAmount - payment.AmountPaid;

--- a/E-Dukate.Presentation/Controllers/Appointments/AppointmentsController.cs
+++ b/E-Dukate.Presentation/Controllers/Appointments/AppointmentsController.cs
@@ -40,16 +40,6 @@ public class AppointmentsController : ControllerBase
         return NoContent();
     }
 
-    [HttpDelete("{id}")]
-    public async Task<IActionResult> Delete(Guid id)
-    {
-        var result = await _appointmentService.DeleteAppointmentAsync(id);
-        if (!result.IsSuccess)
-            return NotFound(new { Error = result.ErrorMessage });
-
-        return NoContent();
-    }
-
     [HttpGet("{id}")]
     public async Task<IActionResult> GetById(Guid id)
     {
@@ -96,24 +86,28 @@ public class AppointmentsController : ControllerBase
         return Ok();
     }
 
-    [HttpPost("{id}/sessions/{sessionId}/cancel")]
-    public async Task<IActionResult> CancelSession(Guid id, Guid sessionId, [FromQuery] Guid patientId)
+    [HttpPut("appointment/{appointmentId}/cancel-session/{sessionId}")]
+    public async Task<IActionResult> CancelSession(
+        Guid appointmentId,
+        Guid sessionId)
     {
-        var result = await _appointmentService.CancelSessionAsync(sessionId, patientId);
+        var result = await _appointmentService.CancelSessionAsync(appointmentId, sessionId);
         if (!result.IsSuccess)
-            return BadRequest(new { Errors = result.ErrorMessage.Split(", ").ToList() });
+            return BadRequest(new { Error = result.ErrorMessage });
 
-        return Ok();
+        return NoContent();
     }
 
-    [HttpPost("{id}/sessions/{sessionId}/reschedule")]
-    public async Task<IActionResult> RescheduleSession(Guid id, Guid sessionId, [FromQuery] Guid patientId, [FromBody] ScheduledSessionDto dto)
+    [HttpPut("reschedule-session/{appointmentId}")]
+    public async Task<IActionResult> RescheduleSession(
+        Guid appointmentId,
+        [FromBody] RescheduleSessionDto dto)
     {
-        var result = await _appointmentService.RescheduleSessionAsync(sessionId, patientId, dto);
+        var result = await _appointmentService.RescheduleSessionAsync(appointmentId, dto);
         if (!result.IsSuccess)
-            return BadRequest(new { Errors = result.ErrorMessage.Split(", ").ToList() });
+            return BadRequest(new { Error = result.ErrorMessage });
 
-        return Ok();
+        return NoContent();
     }
 
     [HttpPost("preview")]


### PR DESCRIPTION
# Pull Request Template 🚀

## 📝 Description
Implemented endpoints for session cancellation and rescheduling in the medical appointment system. The changes include:

1. Session Cancellation:

- Validation of business rules (non-past sessions, previous status, etc.).
- Automatic payment adjustments (partial/full refund based on active sessions).
- Payment status and amount updates.

2. Session Rescheduling:

- Time slot validation and availability checks.
- Automatic new date calculation based on day of the week.
- Conflict verification with existing sessions.

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## 🧪 How Has This Been Tested?
*Tests performed:*

- Business rule validation for cancellation
- Refund calculation verification
- Time conflict testing for rescheduling
- Date and time format validation

*To test in Postman/Swagger:*

Cancellation (PUT):
`PUT /api/Appointments/appointment/{appointmentId}/cancel-session/{sessionId}`

Rescheduling (PUT):
`PUT /api/Appointments/reschedule-session/{appointmentId}`

Body:
 ```
{
  "sessionId": "guid",
  "timeSlotId": "guid",
  "dayOfWeek": "Monday",
  "startTime": "09:00",
  "endTime": "10:00"
}
```
Note: Time slots must match existing slots in the database.

## ✅ Checklist
- [X] 🔎 I have performed a self-review of my own code
- [X] 💬 I have commented my code, particularly in hard-to-understand areas
- [X] 🚫 My changes generate no new warnings

*Additional notes:*

- Days of week must be sent in English ("Monday", "Tuesday", etc.)
- Time formats must follow HH:mm (24-hour format)
- Past sessions cannot be canceled
- Payments are automatically adjusted when canceling sessions