### PR TITLE
feat: id 020 - appointment confirmation

### DIFF
--- a/E-Dukate.Application/Services/Appointments/AppointmentService.cs
+++ b/E-Dukate.Application/Services/Appointments/AppointmentService.cs
@@ -337,20 +337,34 @@ public class AppointmentService
         return Result.Success();
     }
 
-    public async Task<Result> ConfirmSessionAsync(Guid sessionId, Guid patientId)
+    public async Task<Result> ConfirmSessionAsync(Guid appointmentId, Guid sessionId)
     {
-        var session = await _scheduledSessionRepository.GetAll()
-            .Include(ss => ss.Appointment)
-            .ThenInclude(a => a!.Patient)
-            .FirstOrDefaultAsync(ss => ss.Id == sessionId);
-        if (session == null)
-            return Result.Failure("Session not found.");
+        var appointment = await _appointmentRepository.GetAll()
+            .Include(a => a.ScheduledSessions)
+            .Include(a => a.Payment)
+            .FirstOrDefaultAsync(a => a.Id == appointmentId);
+        
+        if (appointment == null)
+            return Result.Failure("Cita no encontrada.");
 
-        if (session.AppointmentId != patientId)
-            return Result.Failure("You do not have permission to confirm this session.");
+        if (appointment.Payment == null)
+            return Result.Failure("La cita no tiene pago asociado.");
+
+        var session = appointment.ScheduledSessions.FirstOrDefault(s => s.Id == sessionId);
+        if (session == null)
+            return Result.Failure("Sesión no encontrada.");
 
         if (session.Status == ScheduledSessionStatus.Cancelled)
-            return Result.Failure("You cannot confirm a cancelled session.");
+            return Result.Failure("No puedes confirmar una sesión cancelada.");
+
+        if (session.Status == ScheduledSessionStatus.Confirmed)
+            return Result.Failure("La sesión ya está confirmada.");
+
+        if (session.StartSessionDateTime <= DateTime.UtcNow)
+            return Result.Failure("No se puede confirmar una sesión pasada.");
+
+        if (appointment.Payment.AmountPaid < appointment.Payment.TotalAmount / 2)
+            return Result.Failure("El monto pagado debe ser al menos la mitad del monto total para confirmar la sesión.");
 
         session.Status = ScheduledSessionStatus.Confirmed;
         await _scheduledSessionRepository.UpdateAsync(session);

--- a/E-Dukate.Presentation/Controllers/Appointments/AppointmentsController.cs
+++ b/E-Dukate.Presentation/Controllers/Appointments/AppointmentsController.cs
@@ -77,13 +77,17 @@ public class AppointmentsController : ControllerBase
     }
 
     [HttpPost("{id}/sessions/{sessionId}/confirm")]
-    public async Task<IActionResult> ConfirmSession(Guid id, Guid sessionId, [FromQuery] Guid patientId)
+    public async Task<IActionResult> ConfirmSession(Guid id, Guid sessionId)
     {
-        var result = await _appointmentService.ConfirmSessionAsync(sessionId, patientId);
+        var result = await _appointmentService.ConfirmSessionAsync(id, sessionId);
         if (!result.IsSuccess)
+        {
+            if (result.ErrorMessage.Contains("no encontrada"))
+                return NotFound(new { Error = result.ErrorMessage });
             return BadRequest(new { Errors = result.ErrorMessage.Split(", ").ToList() });
+        }
 
-        return Ok();
+        return NoContent();
     }
 
     [HttpPut("appointment/{appointmentId}/cancel-session/{sessionId}")]


### PR DESCRIPTION
# Pull Request Template 🚀

## 📝 Description
This PR implements the functionality for administrators and specialist professionals to confirm sessions/appointments in the system. The confirmation updates the session status to "Confirmed" after validating multiple business conditions.

Changes Made
1. API Endpoint:
- New POST endpoint  `/appointments/{id}/sessions/{sessionId}/confirm`
- Accessible only to admin and specialist professional roles

2. *Business Validations:*

- Verifies existence of appointment and session
- Validates session is not cancelled or already confirmed
- Ensures session date is in the future
- Verifies at least 50% of total amount has been paid

3. *API Responses:*
- 204 No Content on success
- 404 Not Found when appointment/session doesn't exist
- 400 Bad Request for validation errors

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## 🧪 How Has This Been Tested?
1. Using Swagger/Postman:

- Authenticate as admin or specialist professional
- Perform POST to `/appointments/{appointmentId}/sessions/{sessionId}/confirm`
- Verify session status changes to "Confirmed"

*Test Scenarios:*
✅ Confirm session with payment ≥50%
❌ Attempt to confirm cancelled session
❌ Attempt to confirm already confirmed session
❌ Attempt to confirm session with payment <50%
❌ Attempt to confirm past session

## ✅ Checklist
- [X] 🔎 I have performed a self-review of my own code
- [X] 🚫 My changes generate no new warnings